### PR TITLE
CronJob Suspend: true/false

### DIFF
--- a/Source/Kubernetes.Helm/templates/cronjob.yaml
+++ b/Source/Kubernetes.Helm/templates/cronjob.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}  
 spec:
   schedule: "{{ .Values.cronJobSchedule }}"
+  suspend: "{{ .Values.cronJobSuspended }}"
   jobTemplate:
     spec:
       concurrencyPolicy: Forbid

--- a/Source/Kubernetes.Helm/values.yaml
+++ b/Source/Kubernetes.Helm/values.yaml
@@ -80,3 +80,9 @@ HostedWorkerConfiguration__MaxConsecutiveErrors: "5"
 #                  |    |    |    |    +---- day of week (0 - 6) (Sunday=0 or 7)
 #                  |    |    |    |    | 
 cronJobSchedule: "*/15  *    *    *    *"
+
+# Suspend the cronJob to start
+#
+#    If false, the cronjob is actively scheduling job, if true existing job will not be forced 
+#    to terminate but new ones cannot be scheduled;
+cronJobSuspended: "false"


### PR DESCRIPTION
Nova opção para deixar o CronJob suspenço quando necessário. Default é falso.